### PR TITLE
Fix comment in KruskalMaze

### DIFF
--- a/QLearning/MazeGenerator/KruskalMaze.py
+++ b/QLearning/MazeGenerator/KruskalMaze.py
@@ -220,7 +220,7 @@ class RectangularKruskalMaze:
         if file_name is not None:
             maze_image.save(file_name)
         else:
-            # if path not provided, return edges and imaeg
+            # if path not provided, return edges and image
 
             # sort the edges so they could be saved as graph representation and compared to avoid duplicate trees
             # each edge has a smaller indexed node at index 0. we will sort by using that vertex, all the edge tuples


### PR DESCRIPTION
## Summary
- fix comment describing return behavior if no path is provided

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fab449b2c832693b998cf142ee603